### PR TITLE
Scatter multi-register tables on setup

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/multiregister.clj
+++ b/cockroachdb/src/jepsen/cockroach/multiregister.clj
@@ -61,6 +61,7 @@
           (doseq [t table-names]
             (j/execute! c [(str "create table " t
                                 " (ik int primary key, val int)")])
+            (j/execute! c [(str "alter table " t " scatter")])
             (info "Created table" t))))))
 
   (invoke! [this test op]


### PR DESCRIPTION
This should help spread the tables over the cluster.