### PR TITLE
cockroachdb: fix table scattering in multi-register

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/multiregister.clj
+++ b/cockroachdb/src/jepsen/cockroach/multiregister.clj
@@ -61,7 +61,7 @@
           (doseq [t table-names]
             (j/execute! c [(str "create table " t
                                 " (ik int primary key, val int)")])
-            (j/execute! c [(str "alter table " t " scatter")])
+            (j/query    c [(str "alter table " t " scatter")])
             (info "Created table" t))))))
 
   (invoke! [this test op]


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/37470.
Fixes https://github.com/cockroachdb/cockroach/issues/37471.
Fixes https://github.com/cockroachdb/cockroach/issues/37472.
Fixes https://github.com/cockroachdb/cockroach/issues/37473.
Fixes https://github.com/cockroachdb/cockroach/issues/37474.
Fixes https://github.com/cockroachdb/cockroach/issues/37475.

This was failing with the following error:
```
org.postgresql.util.PSQLException: A result was returned when none was expected.
```

Using `c/query` instead of `c/execute!` fixes this (this time I confirmed).