### PR TITLE
Use NULL as the tz argument for settimeofday().

### DIFF
--- a/cockroachdb/resources/bumptime.c
+++ b/cockroachdb/resources/bumptime.c
@@ -17,9 +17,8 @@ int main(int argc, char **argv) {
 
     /* Get current time */
     struct timeval time;
-    struct timezone tz;
 
-    if (0 != gettimeofday(&time, &tz)) {
+    if (0 != gettimeofday(&time, NULL)) {
       perror("gettimeofday");
       return 1;
     }
@@ -38,7 +37,7 @@ int main(int argc, char **argv) {
     }
 
     /* Set time */
-    if (0 != settimeofday(&time, &tz)) {
+    if (0 != settimeofday(&time, NULL)) {
       perror("settimeofday");
       return 2;
     }


### PR DESCRIPTION
Without this, `bumptime` doesn't work on Ubuntu 20.04.
Quoth `man settimeofday`:

"The use of the timezone structure is obsolete; the tz argument should
 normally be specified as NULL."

We don't need it for `gettimeofday` either, so we can just delete the
entire variable.