### PR TITLE
cockroachdb: use pool.ntp.org to avoid throttling

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/auto.clj
+++ b/cockroachdb/src/jepsen/cockroach/auto.clj
@@ -223,7 +223,7 @@
   (info node "Cockroach killed.")
   :killed)
 
-(def ntpserver "ntp.ubuntu.com")
+(def ntpserver "pool.ntp.org")
 
 (defn reset-clock!
   "Reset clock on this host. Logs output."


### PR DESCRIPTION
strobe-skews are throttled by frequent resyncs with ntp.ubuntu.org
we can switch to pool to get more bandwidth.

This should fix out problem with https://github.com/cockroachdb/cockroach/issues/35599 so we could reenable those tests.