### PR TITLE
cockroachdb: workaround for settimeofday tz

### DIFF
--- a/cockroachdb/resources/strobetime.c
+++ b/cockroachdb/resources/strobetime.c
@@ -1,0 +1,156 @@
+#include <stdio.h>
+#include <time.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+const int64_t NANOS_PER_SEC = 1000000000;
+
+# define TIMEVAL_TO_TIMESPEC(tv, ts) {                                   \
+    (ts)->tv_sec = (tv)->tv_sec;                                    \
+    (ts)->tv_nsec = (tv)->tv_usec * 1000;                           \
+}
+# define TIMESPEC_TO_TIMEVAL(tv, ts) {                                   \
+    (tv)->tv_sec = (ts)->tv_sec;                                    \
+    (tv)->tv_usec = (ts)->tv_nsec / 1000;                           \
+}
+
+/* Convert nanoseconds to a timespec */
+struct timespec nanos_to_timespec(int64_t nanos) {
+  struct timespec t;
+  int64_t dnanos   = nanos % NANOS_PER_SEC;
+  int64_t dseconds = (nanos - dnanos) / NANOS_PER_SEC;
+  t.tv_nsec = dnanos;
+  t.tv_sec = dseconds;
+  return t;
+}
+
+/* Obtain monotonic clock as a timespec */
+struct timespec monotonic_now() {
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  return now;
+}
+
+/* Obtain wall clock as a timespec */
+struct timespec wall_now() {
+  struct timespec now_ts;
+  struct timeval  now_tv;
+  struct timezone tz;
+  if (0 != gettimeofday(&now_tv, &tz)) {
+    perror("gettimeofday");
+    exit(1);
+  }
+  TIMEVAL_TO_TIMESPEC(&now_tv, &now_ts);
+  return now_ts;
+}
+
+/* Set wall clock */
+void set_wall_clock(struct timespec ts) {
+  struct timeval tv;
+  TIMESPEC_TO_TIMEVAL(&tv, &ts);
+  // printf("Setting clock: %d %d\n", tv.tv_sec, tv.tv_usec);
+  if (0 != settimeofday(&tv, NULL)) {
+    perror("settimeofday");
+    exit(2);
+  }
+}
+
+/* Rebalances sec/nsec to be within bounds. Mutates t.*/
+void balance_timespec_m(struct timespec *t) {
+  while (t->tv_nsec <= NANOS_PER_SEC) {
+    t->tv_sec -= 1;
+    t->tv_nsec += NANOS_PER_SEC;
+  }
+  while (NANOS_PER_SEC <= t->tv_nsec) {
+    t->tv_sec += 1;
+    t->tv_nsec -= NANOS_PER_SEC;
+  }
+}
+
+/* Add two timespecs, returning their sum */
+struct timespec add_timespec(struct timespec a, struct timespec b) {
+  struct timespec result;
+  result.tv_sec = a.tv_sec + b.tv_sec;
+  result.tv_nsec = a.tv_nsec + b.tv_nsec;
+  balance_timespec_m(&result);
+  return result;
+}
+
+/* Subtract one timespec from another, returning their difference. */
+struct timespec sub_timespec(struct timespec a, struct timespec b) {
+  struct timespec result;
+  result.tv_sec = a.tv_sec - b.tv_sec;
+  result.tv_nsec = a.tv_nsec - b.tv_nsec;
+  balance_timespec_m(&result);
+  return result;
+}
+
+/* Standard -1, 0, +1 comparator over timespecs */
+int8_t cmp_timespec(struct timespec a, struct timespec b) {
+  if (a.tv_sec < b.tv_sec) {
+    return 1;
+  } else if (b.tv_sec < a.tv_sec) {
+    return -1;
+  } else {
+    if (a.tv_nsec < b.tv_nsec) {
+      return 1;
+    } else if (b.tv_nsec < a.tv_nsec) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <delta> <period> <duration>\n", argv[0]);
+    fprintf(stderr, "Delta and period are in ms, duration is in seconds. "
+        "Every period ms, adjusts the clock forward by delta ms, or, "
+        "alternatively, back by delta ms. Does this for duration seconds, "
+        "then exits. Useful for confusing the heck out of systems that "
+        "assume clocks are monotonic and linear.\n");
+    return 1;
+  }
+
+  /* Parse args */
+  struct timespec delta     = nanos_to_timespec(atof(argv[1]) * 1000000);
+  struct timespec period    = nanos_to_timespec(atof(argv[2]) * 1000000);
+  struct timespec duration  = nanos_to_timespec(atof(argv[3]) * 1000000000);
+
+  /* How far ahead of the monotonic clock is wall time? */
+  struct timespec normal_offset = sub_timespec(wall_now(), monotonic_now());
+  struct timespec weird_offset  = add_timespec(normal_offset, delta);
+
+  /* And somewhere to store nanosleep remainders */
+  struct timespec rem;
+
+  /* When (in monotonic time) should we stop changing the clock? */
+  struct timespec end = add_timespec(monotonic_now(), duration);
+
+  /* Are we in weird time mode or not? */
+  int8_t weird = 0;
+
+  /* Number of adjustments */
+  int64_t count = 0;
+
+  /* Strobe the clock until duration's up! */
+  while (0 < cmp_timespec(monotonic_now(), end)) {
+    set_wall_clock(add_timespec(monotonic_now(),
+                                (weird ? normal_offset : weird_offset)));
+    // printf("Time now:      %d %d\n", wall_now().tv_sec, wall_now().tv_nsec);
+    weird = !weird;
+    count += 1;
+
+    if (0 != nanosleep(&period, &rem)) {
+      perror("nanosleep");
+      exit(3);
+    }
+  }
+
+  /* Reset clock and print number of changes */
+  set_wall_clock(add_timespec(monotonic_now(), normal_offset));
+  printf("%d\n", count);
+  return 0;
+}

--- a/cockroachdb/src/jepsen/cockroach.clj
+++ b/cockroachdb/src/jepsen/cockroach.clj
@@ -23,6 +23,7 @@
             [jepsen.control.net :as cn]
             [jepsen.os.ubuntu :as ubuntu]
             [jepsen.cockroach [nemesis :as cln]
+                              [time :as ct]
                               [auto :as auto :refer [cockroach-user
                                                      cockroach
                                                      jdbc-mode
@@ -54,7 +55,7 @@
 
       (when (= jdbc-mode :cdb-cluster)
         (auto/install! test node)
-        (auto/reset-clock!)
+        (ct/reset-clock!)
         (jepsen/synchronize test)
 
         (c/sudo cockroach-user
@@ -102,7 +103,7 @@
 
     (teardown! [_ test node]
       (when (= jdbc-mode :cdb-cluster)
-        (auto/reset-clock!)
+        (ct/reset-clock!)
 
         (c/su
           (auto/kill! test node)

--- a/cockroachdb/src/jepsen/cockroach/nemesis.clj
+++ b/cockroachdb/src/jepsen/cockroach/nemesis.clj
@@ -10,6 +10,7 @@
             [jepsen.nemesis.time :as nt]
             [jepsen.cockroach.client :as cc]
             [jepsen.cockroach.auto :as auto]
+            [jepsen.cockroach.time :as ct]
             [clojure.set :as set]
             [clojure.java.jdbc :as j]
             [clojure.string :as str]
@@ -206,18 +207,18 @@
   (restarting
    (reify nemesis/Nemesis
      (setup! [this test]
-       (auto/reset-clocks! test)
+       (ct/reset-clocks! test)
        this)
 
      (invoke! [this test op]
        (assoc op :value
               (case (:f op)
                 :start (c/with-test-nodes test
-                         (nt/strobe-time! delta period duration))
+                         (ct/strobe-time! delta period duration))
                 :stop nil)))
 
      (teardown! [this test]
-       (auto/reset-clocks! test)))))
+       (ct/reset-clocks! test)))))
 
 (defn strobe-skews
   []
@@ -236,7 +237,7 @@
   (restarting
    (reify nemesis/Nemesis
      (setup! [this test]
-       (auto/reset-clocks! test)
+       (ct/reset-clocks! test)
        this)
 
      (invoke! [this test op]
@@ -244,15 +245,14 @@
               (case (:f op)
                 :start (c/with-test-nodes test
                          (if (< (rand) 0.5)
-                           (do (c/su (c/exec "/opt/jepsen/bumptime"
-                                             (* 1000 dt)))
+                           (do (ct/bump-time! (* 1000 dt))
                                dt)
                            0))
                 :stop (c/with-test-nodes test
-                        (auto/reset-clock!)))))
+                        (ct/reset-clock!)))))
 
      (teardown! [this test]
-       (auto/reset-clocks! test)))))
+       (ct/reset-clocks! test)))))
 
 (defn skew
   "A skew nemesis"

--- a/cockroachdb/src/jepsen/cockroach/time.clj
+++ b/cockroachdb/src/jepsen/cockroach/time.clj
@@ -1,0 +1,37 @@
+(ns jepsen.cockroach.time
+  "Overrides for time functions to workaround bugs in jepsen packages."
+  (:require [clojure.tools.logging :refer :all]
+            [jepsen
+             [control :as c]]
+            [jepsen.nemesis.time :as nt]
+            [jepsen.os.debian :as debian]))
+
+(defn install!
+  "Install time manipulation utils"
+  []
+  (c/su
+   (debian/install [:build-essential])
+   (nt/compile-resource! "bumptime.c" "bumptime")
+   (nt/compile-resource! "strobetime.c" "strobetime")))
+
+(defn bump-time!
+  "Adjust clocks"
+  [delta]
+  (c/su (c/exec "/opt/jepsen/bumptime" delta)))
+
+(defn strobe-time!
+  "Strobe time back and forth"
+  [delta period duration]
+  (c/su (c/exec "/opt/jepsen/strobetime" delta period duration)))
+
+(def ntpserver "pool.ntp.org")
+
+(defn reset-clock!
+  "Reset clock on this host. Logs output."
+  []
+  (info c/*host* "clock reset:" (c/su (c/exec :ntpdate :-b ntpserver))))
+
+(defn reset-clocks!
+  "Reset all clocks on all nodes in a test"
+  [test]
+  (c/with-test-nodes test (reset-clock!)))


### PR DESCRIPTION
TZ argument is not accepted on newer systems so we needto fix utilities to work.

We rely on stable version of jepsen to run tests and binary utilities are part of the package so they can't be immediately fixed. We already have a copy of bumptime for the same reason. Following this trend, this PR adds fixed strobetime utility to cockroach tests.

All the overridden functions for bumptime and strobetime are moved to time.clj so that it is clear which parts we had to override and they could be dropped once we move to up to date release version where those bugs are fixed.