### PR TITLE
Allow smaller ranges in Jepsen tests

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/auto.clj
+++ b/cockroachdb/src/jepsen/cockroach/auto.clj
@@ -167,7 +167,8 @@
                      (str "--join="))]]
     (wrap-env [(str "COCKROACH_LINEARIZABLE="
                     (if (:linearizable test) "true" "false"))
-               (str "COCKROACH_MAX_OFFSET=" "250ms")]
+               (str "COCKROACH_MAX_OFFSET=" "250ms")
+               (str "COCKROACH_MIN_RANGE_MAX_BYTES=0")]
               (cockroach-start-cmdline join))))
 
 (defn start!


### PR DESCRIPTION
Jepsen attempts to set custom range sizes using values not allowed under the new validation added in [1]. We disable that validation by setting the COCKROACH_MIN_RANGE_MAX_BYTES environment variable when startting cockroachdb.

[1] https://github.com/cockroachdb/cockroach/pull/96725