### PR TITLE
cockroachdb: make context-deadline-exceeded detailed

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/client.clj
+++ b/cockroachdb/src/jepsen/cockroach/client.clj
@@ -213,7 +213,7 @@
         {:type :fail, :error :connection-refused}
 
         #"context deadline exceeded"
-        {:type :fail, :error :context-deadline-exceeded}
+        {:type :fail, :error [:context-deadline-exceeded m]}
 
         #"rejecting command with timestamp in the future"
         {:type :fail, :error :reject-command-future-timestamp}


### PR DESCRIPTION
Jepsen does best effort on interpreting the PSQLException that it may get from CRDB, by matching it against regexps. The "context deadline exceeded" substring is overly general, and may match a large class of errors which only contain this substring as one of its components.

Since we have seen test failures in CRDB involving this error, we would like to have more introspection into them. This commit adds the full error message to the log, instead of condensing it to an obscure `:context-deadline-exceeded`.