### PR TITLE
cockroachdb: fix handling of ambiguous errors

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/client.clj
+++ b/cockroachdb/src/jepsen/cockroach/client.clj
@@ -212,9 +212,6 @@
         #"Connection .+? refused"
         {:type :fail, :error :connection-refused}
 
-        #"context deadline exceeded"
-        {:type :fail, :error [:context-deadline-exceeded m]}
-
         #"rejecting command with timestamp in the future"
         {:type :fail, :error :reject-command-future-timestamp}
 
@@ -224,6 +221,15 @@
         #"restart transaction"
         {:type :fail, :error [:restart-transaction m]}
 
+        ; Explicitly indicates that the operation may or may not succeed.
+        #"result is ambiguous"
+        {:type :info, :error [:result-ambiguous m]}
+
+        ; By default, interpret errors as ambiguous by marking them as :info.
+        ;
+        ; TODO(pavelkalinnikov): do better at detecting "ambiguous" errors
+        ; above. If all the cases are covered above, we can then safely assign
+        ; type :fail to unknown errors by default.
         {:type :info, :error [:psql-exception m]})
 
       clojure.lang.ExceptionInfo


### PR DESCRIPTION
Jepsen does best effort on interpreting the `PSQLException` that it may get from CRDB, by matching it against regexps. The "context deadline exceeded" substring is overly general, and may match a large class of errors which only contain this substring as one of its components.

One of the errors that it matches looks like this:

	ERROR: result is ambiguous: error=failed to connect to n5 at <node>:26257:
	operation "conn heartbeat" timed out after 6s (given timeout 6s): grpc: context
	deadline exceeded [code 4/DeadlineExceeded] [exhausted]

CRDB has a whole class of errors called "ambiguous error" which mean that an operation may or may not have succeeded. Currenly, Jepsen erroneously marks this error as `:fail` (which means "definitely failed" rather than "tentatively failed"), because the regexp matches "context deadline exceeded".

This commit parses ambiguous errors explicitly, and marks them as `:info` errors, so that Jepsen tests don't interpret them as definite failures. This is not strictly necessary, because all errors are marked as such by default (if not match all other regexps); but we do it to be explicit.

See https://github.com/cockroachdb/cockroach/issues/104602